### PR TITLE
MP-PMT-002 Prompt Metadata Expansion & UI Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 - Initial skeleton structure for React Native + FastAPI monorepo template.
+- MP-PMT-002: expanded prompt metadata model, CRUD APIs and UI scaffolding.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ This repository serves as a **template** for bootstrapping new mobile and web ap
 
 Refer to `docs/DEVELOPER_GUIDE.md` for detailed environment setup and commands.
 
+## Prompt Metadata Spec
+
+The prompts service supports a rich set of governance fields to aid in
+discovery and reuse.  Each prompt captures:
+
+* **title** – human friendly name.
+* **body** – the prompt text.
+* **use_cases** – list describing intended scenarios.
+* **access_control** – one of `public`, `private`, `team-only`, or
+  `role-based`.
+* Optional details such as target models, providers, integrations,
+  audience, input/output samples and related prompt links.
+
+Timestamps for creation and last modification are managed by the
+database.  See the OpenAPI docs for the full schema.
+
 ## License
 
 This template is provided under the terms of the [MIT License](LICENSE).  See the `LICENSE` file for details.

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',

--- a/apps/web/src/components/PromptCard.tsx
+++ b/apps/web/src/components/PromptCard.tsx
@@ -4,12 +4,8 @@ import React from 'react';
 interface Prompt {
   title: string;
   body: string;
-  version: number;
+  version: string;
   tags?: string[];
-  purpose?: string[];
-  models?: string[];
-  tools?: string[];
-  platforms?: string[];
 }
 
 interface PromptCardProps {
@@ -24,13 +20,7 @@ const Tag: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 );
 
 const PromptCard: React.FC<PromptCardProps> = ({ prompt, onClick }) => {
-  const allTags = [
-    ...(prompt.purpose || []),
-    ...(prompt.models || []),
-    ...(prompt.tools || []),
-    ...(prompt.platforms || []),
-    ...(prompt.tags || [])
-  ];
+  const allTags = prompt.tags || [];
 
   return (
     <div

--- a/apps/web/src/components/PromptDetailModal.tsx
+++ b/apps/web/src/components/PromptDetailModal.tsx
@@ -9,13 +9,14 @@ import {
 } from './ui/dialog'; // Assuming shadcn dialog is in ui/dialog
 import { Button } from './ui/button'; // Assuming shadcn button is in ui/button
 
-// This is a placeholder for the actual Prompt data type
+// Simplified Prompt type used by this component
 interface Prompt {
   title: string;
-  purpose: string[];
-  models: string[];
-  platforms: string[];
   body: string;
+  sample_input?: Record<string, unknown>;
+  sample_output?: Record<string, unknown>;
+  related_prompt_ids?: string[];
+  link?: string;
 }
 
 interface PromptDetailModalProps {
@@ -71,7 +72,73 @@ const PromptDetailModal: React.FC<PromptDetailModalProps> = ({ prompt, isOpen, o
             )}
           </div>
 
-          {/* Add other fields here (Purpose, Models, Platforms) in a similar fashion */}
+          {/* Sample Input */}
+          <div className="grid grid-cols-4 items-start gap-4">
+            <label htmlFor="sample_input" className="text-right mt-2">Sample Input</label>
+            {isEditing ? (
+              <textarea
+                id="sample_input"
+                value={JSON.stringify(editedPrompt.sample_input ?? {}, null, 2)}
+                onChange={(e) =>
+                  setEditedPrompt({
+                    ...editedPrompt,
+                    sample_input: JSON.parse(e.target.value || '{}'),
+                  })
+                }
+                className="col-span-3 p-2 border rounded h-24"
+              />
+            ) : (
+              <pre className="col-span-3 whitespace-pre-wrap text-sm">
+                {JSON.stringify(prompt.sample_input, null, 2)}
+              </pre>
+            )}
+          </div>
+
+          {/* Sample Output */}
+          <div className="grid grid-cols-4 items-start gap-4">
+            <label htmlFor="sample_output" className="text-right mt-2">Sample Output</label>
+            {isEditing ? (
+              <textarea
+                id="sample_output"
+                value={JSON.stringify(editedPrompt.sample_output ?? {}, null, 2)}
+                onChange={(e) =>
+                  setEditedPrompt({
+                    ...editedPrompt,
+                    sample_output: JSON.parse(e.target.value || '{}'),
+                  })
+                }
+                className="col-span-3 p-2 border rounded h-24"
+              />
+            ) : (
+              <pre className="col-span-3 whitespace-pre-wrap text-sm">
+                {JSON.stringify(prompt.sample_output, null, 2)}
+              </pre>
+            )}
+          </div>
+
+          {/* Related Prompts */}
+          {prompt.related_prompt_ids && (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <span className="text-right">Related</span>
+              <div className="col-span-3 flex flex-col space-y-1">
+                {prompt.related_prompt_ids.map((id) => (
+                  <a key={id} href={`/prompts/${id}`} className="text-blue-500 underline">
+                    {id}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* External Link */}
+          {prompt.link && (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <span className="text-right">Link</span>
+              <a href={prompt.link} className="col-span-3 text-blue-500 underline">
+                {prompt.link}
+              </a>
+            </div>
+          )}
 
         </div>
 

--- a/apps/web/src/components/forms/ManualPromptForm.tsx
+++ b/apps/web/src/components/forms/ManualPromptForm.tsx
@@ -10,13 +10,13 @@ import { useLookups } from '@/contexts/LookupContext';
 
 const schema = z.object({
   title: z.string().min(1, 'Title is required'),
-  purpose: z.array(z.string()).optional(),
-  models: z.array(z.string()).min(1, 'At least one model is required'),
-  tools: z.array(z.string()).optional(),
-  platforms: z.array(z.string()).optional(),
+  use_cases: z.array(z.string()).min(1, 'Use case is required'),
+  target_models: z.array(z.string()).min(1, 'At least one model is required'),
+  providers: z.array(z.string()).optional(),
+  integrations: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   body: z.string().min(1, 'Prompt text is required'),
-  visibility: z.enum(['private', 'public', 'team']),
+  access_control: z.enum(['public', 'private', 'team-only', 'role-based']),
 });
 
 const ManualPromptForm = ({ onClose }) => {
@@ -32,10 +32,10 @@ const ManualPromptForm = ({ onClose }) => {
   } = useForm<ManualPromptInput>({
     resolver: zodResolver(schema),
     defaultValues: {
-      models: [],
-      tools: [],
-      platforms: [],
-      purpose: [],
+      target_models: [],
+      providers: [],
+      integrations: [],
+      use_cases: [],
       tags: [],
     }
   });
@@ -51,7 +51,7 @@ const ManualPromptForm = ({ onClose }) => {
     }
   };
 
-  const handleCreateOption = (type: 'models' | 'tools' | 'platforms' | 'purposes') => (inputValue: string) => {
+  const handleCreateOption = (type: 'target_models' | 'providers' | 'integrations' | 'use_cases') => (inputValue: string) => {
     addLookup(type, inputValue);
   };
 
@@ -81,53 +81,53 @@ const ManualPromptForm = ({ onClose }) => {
         {errors.body && <p className="text-red-500">{errors.body.message}</p>}
       </div>
 
-      {/* Models */}
+      {/* Target Models */}
       <div>
-        <label htmlFor="models" className="block text-sm font-medium text-gray-700">
-          Models
+        <label htmlFor="target_models" className="block text-sm font-medium text-gray-700">
+          Target Models
         </label>
         <Controller
-          name="models"
+          name="target_models"
           control={control}
           render={({ field }) => (
             <CreatableMultiSelect
               isLoading={lookups.loading}
-              options={lookups.models}
-              value={lookups.models.filter(o => field.value?.includes(o.value))}
+              options={lookups.target_models}
+              value={lookups.target_models.filter(o => field.value?.includes(o.value))}
               onChange={(options) => field.onChange(options.map(o => o.value))}
-              onCreateOption={handleCreateOption('models')}
+              onCreateOption={handleCreateOption('target_models')}
               placeholder="Select or create models..."
             />
           )}
         />
-        {errors.models && <p className="text-red-500">{errors.models.message}</p>}
+        {errors.target_models && <p className="text-red-500">{errors.target_models.message}</p>}
       </div>
 
-      {/* Purpose */}
+      {/* Use Cases */}
       <div>
-        <label htmlFor="purpose" className="block text-sm font-medium text-gray-700">Purpose</label>
-        <Controller name="purpose" control={control} render={({ field }) => (
-            <CreatableMultiSelect isLoading={lookups.loading} options={lookups.purposes} value={lookups.purposes.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('purposes')} />
+        <label htmlFor="use_cases" className="block text-sm font-medium text-gray-700">Use Cases</label>
+        <Controller name="use_cases" control={control} render={({ field }) => (
+            <CreatableMultiSelect isLoading={lookups.loading} options={lookups.use_cases} value={lookups.use_cases.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('use_cases')} />
         )} />
-        {errors.purpose && <p className="text-red-500">{errors.purpose.message}</p>}
+        {errors.use_cases && <p className="text-red-500">{errors.use_cases.message}</p>}
       </div>
 
-      {/* Tools */}
+      {/* Providers */}
       <div>
-        <label htmlFor="tools" className="block text-sm font-medium text-gray-700">Tools</label>
-        <Controller name="tools" control={control} render={({ field }) => (
-            <CreatableMultiSelect isLoading={lookups.loading} options={lookups.tools} value={lookups.tools.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('tools')} />
+        <label htmlFor="providers" className="block text-sm font-medium text-gray-700">Providers</label>
+        <Controller name="providers" control={control} render={({ field }) => (
+            <CreatableMultiSelect isLoading={lookups.loading} options={lookups.providers} value={lookups.providers.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('providers')} />
         )} />
-        {errors.tools && <p className="text-red-500">{errors.tools.message}</p>}
+        {errors.providers && <p className="text-red-500">{errors.providers.message}</p>}
       </div>
 
-      {/* Platforms */}
+      {/* Integrations */}
       <div>
-        <label htmlFor="platforms" className="block text-sm font-medium text-gray-700">Platforms</label>
-        <Controller name="platforms" control={control} render={({ field }) => (
-            <CreatableMultiSelect isLoading={lookups.loading} options={lookups.platforms} value={lookups.platforms.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('platforms')} />
+        <label htmlFor="integrations" className="block text-sm font-medium text-gray-700">Integrations</label>
+        <Controller name="integrations" control={control} render={({ field }) => (
+            <CreatableMultiSelect isLoading={lookups.loading} options={lookups.integrations} value={lookups.integrations.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('integrations')} />
         )} />
-        {errors.platforms && <p className="text-red-500">{errors.platforms.message}</p>}
+        {errors.integrations && <p className="text-red-500">{errors.integrations.message}</p>}
       </div>
 
       {/* Tags */}
@@ -140,19 +140,20 @@ const ManualPromptForm = ({ onClose }) => {
       </div>
 
       <div>
-        <label htmlFor="visibility" className="block text-sm font-medium text-gray-700">
-          Visibility
+        <label htmlFor="access_control" className="block text-sm font-medium text-gray-700">
+          Access Control
         </label>
         <select
-          id="visibility"
-          {...register('visibility')}
+          id="access_control"
+          {...register('access_control')}
           className="block w-full mt-1 text-black border-gray-300 rounded-md shadow-md"
         >
           <option value="public">Public</option>
           <option value="private">Private</option>
-          <option value="team">Team</option>
+          <option value="team-only">Team Only</option>
+          <option value="role-based">Role Based</option>
         </select>
-        {errors.visibility && <p className="text-red-500">{errors.visibility.message}</p>}
+        {errors.access_control && <p className="text-red-500">{errors.access_control.message}</p>}
       </div>
       {/* Add other form fields here */}
       <div className="flex justify-end mt-6">

--- a/apps/web/src/contexts/LookupContext.tsx
+++ b/apps/web/src/contexts/LookupContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { getLookups, createLookup } from '../lib/api/lookups';
 
-type LookupType = 'models' | 'tools' | 'platforms' | 'purposes';
+type LookupType = 'target_models' | 'providers' | 'integrations' | 'use_cases';
 
 interface Option {
   value: string;
@@ -9,10 +9,10 @@ interface Option {
 }
 
 interface LookupState {
-  models: Option[];
-  tools: Option[];
-  platforms: Option[];
-  purposes: Option[];
+  target_models: Option[];
+  providers: Option[];
+  integrations: Option[];
+  use_cases: Option[];
   loading: boolean;
 }
 
@@ -25,28 +25,28 @@ const LookupContext = createContext<LookupContextType | undefined>(undefined);
 
 export const LookupProvider = ({ children }: { children: ReactNode }) => {
   const [lookups, setLookups] = useState<LookupState>({
-    models: [],
-    tools: [],
-    platforms: [],
-    purposes: [],
+    target_models: [],
+    providers: [],
+    integrations: [],
+    use_cases: [],
     loading: true,
   });
 
   useEffect(() => {
     const fetchAllLookups = async () => {
       try {
-        const [models, tools, platforms, purposes] = await Promise.all([
-          getLookups('models'),
-          getLookups('tools'),
-          getLookups('platforms'),
-          getLookups('purposes'),
+        const [target_models, providers, integrations, use_cases] = await Promise.all([
+          getLookups('target_models'),
+          getLookups('providers'),
+          getLookups('integrations'),
+          getLookups('use_cases'),
         ]);
 
         setLookups({
-          models: models.map(m => ({ value: m.value, label: m.value })),
-          tools: tools.map(t => ({ value: t.value, label: t.value })),
-          platforms: platforms.map(p => ({ value: p.value, label: p.value })),
-          purposes: purposes.map(p => ({ value: p.value, label: p.value })),
+          target_models: target_models.map(m => ({ value: m.value, label: m.value })),
+          providers: providers.map(t => ({ value: t.value, label: t.value })),
+          integrations: integrations.map(p => ({ value: p.value, label: p.value })),
+          use_cases: use_cases.map(p => ({ value: p.value, label: p.value })),
           loading: false,
         });
       } catch (error) {

--- a/apps/web/src/lib/api/lookups.ts
+++ b/apps/web/src/lib/api/lookups.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
-type LookupType = 'models' | 'tools' | 'platforms' | 'purposes';
+type LookupType = 'target_models' | 'providers' | 'integrations' | 'use_cases';
 
 interface Lookup {
   id: string;

--- a/apps/web/src/types/Prompt.ts
+++ b/apps/web/src/types/Prompt.ts
@@ -1,16 +1,29 @@
 export interface Prompt {
   id: string;
-  title: string;
-  purpose?: string[];
-  models: string[];
-  platforms?: string[];
-  tools?: string[];
-  tags?: string[];
-  body: string;
-  visibility: 'private' | 'public' | 'team';
-  version: number;
-  createdAt: string;
   prompt_id: string;
+  version: string;
+  title: string;
+  body: string;
+  use_cases: string[];
+  access_control: 'public' | 'private' | 'team-only' | 'role-based';
+  target_models?: string[];
+  providers?: string[];
+  integrations?: string[];
+  category?: string;
+  complexity?: string;
+  audience?: string;
+  status?: string;
+  input_schema?: Record<string, unknown>;
+  output_format?: string;
+  llm_parameters?: Record<string, unknown>;
+  success_metrics?: Record<string, unknown>;
+  sample_input?: Record<string, unknown>;
+  sample_output?: Record<string, unknown>;
+  related_prompt_ids?: string[];
+  link?: string;
+  tags?: string[];
+  createdAt: string;
+  updatedAt: string;
 }
 
-export type ManualPromptInput = Omit<Prompt, 'id' | 'version' | 'createdAt' | 'prompt_id'>;
+export type ManualPromptInput = Omit<Prompt, 'id' | 'version' | 'createdAt' | 'updatedAt' | 'prompt_id'>;

--- a/services/api/alembic/versions/b1e8d8e2c3d0_mp_pmt_002_prompt_metadata.py
+++ b/services/api/alembic/versions/b1e8d8e2c3d0_mp_pmt_002_prompt_metadata.py
@@ -1,0 +1,90 @@
+"""MP-PMT-002 expand prompt metadata"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'b1e8d8e2c3d0'
+down_revision = 'a94a2ac10fe2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # prompts table
+    op.add_column('prompts', sa.Column('title', sa.String(), nullable=False))
+    op.add_column('prompts', sa.Column('tags', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column(
+        'prompts',
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.drop_column('prompts', 'slug')
+    op.drop_column('prompts', 'latest_version_id')
+    op.drop_column('prompts', 'created_by')
+
+    # prompt_versions table
+    op.drop_column('prompt_versions', 'title')
+    op.alter_column('prompt_versions', 'purpose', new_column_name='use_cases')
+    op.drop_column('prompt_versions', 'models')
+    op.drop_column('prompt_versions', 'tools')
+    op.drop_column('prompt_versions', 'platforms')
+    op.drop_column('prompt_versions', 'tags')
+    op.drop_column('prompt_versions', 'visibility')
+    op.alter_column('prompt_versions', 'version', type_=sa.String())
+    op.add_column('prompt_versions', sa.Column('description', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('access_control', sa.String(), nullable=False, server_default='private'))
+    op.add_column('prompt_versions', sa.Column('target_models', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('providers', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('integrations', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('category', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('complexity', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('audience', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('status', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('input_schema', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('output_format', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('llm_parameters', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('success_metrics', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('sample_input', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('sample_output', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('related_prompt_ids', postgresql.ARRAY(sa.UUID()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('link', sa.String(), nullable=True))
+    op.add_column(
+        'prompt_versions',
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('prompt_versions', 'updated_at')
+    op.drop_column('prompt_versions', 'link')
+    op.drop_column('prompt_versions', 'related_prompt_ids')
+    op.drop_column('prompt_versions', 'sample_output')
+    op.drop_column('prompt_versions', 'sample_input')
+    op.drop_column('prompt_versions', 'success_metrics')
+    op.drop_column('prompt_versions', 'llm_parameters')
+    op.drop_column('prompt_versions', 'output_format')
+    op.drop_column('prompt_versions', 'input_schema')
+    op.drop_column('prompt_versions', 'status')
+    op.drop_column('prompt_versions', 'audience')
+    op.drop_column('prompt_versions', 'complexity')
+    op.drop_column('prompt_versions', 'category')
+    op.drop_column('prompt_versions', 'integrations')
+    op.drop_column('prompt_versions', 'providers')
+    op.drop_column('prompt_versions', 'target_models')
+    op.drop_column('prompt_versions', 'access_control')
+    op.drop_column('prompt_versions', 'description')
+    op.alter_column('prompt_versions', 'version', type_=sa.INTEGER())
+    op.add_column('prompt_versions', sa.Column('visibility', sa.String(), nullable=True))
+    op.add_column('prompt_versions', sa.Column('tags', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('platforms', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('tools', postgresql.ARRAY(sa.String()), nullable=True))
+    op.add_column('prompt_versions', sa.Column('models', postgresql.ARRAY(sa.String()), nullable=False))
+    op.alter_column('prompt_versions', 'use_cases', new_column_name='purpose')
+    op.add_column('prompt_versions', sa.Column('title', sa.String(), nullable=False))
+
+    op.add_column('prompts', sa.Column('created_by', sa.UUID(), nullable=True))
+    op.add_column('prompts', sa.Column('latest_version_id', sa.UUID(), nullable=True))
+    op.add_column('prompts', sa.Column('slug', sa.String(), nullable=True))
+    op.drop_column('prompts', 'updated_at')
+    op.drop_column('prompts', 'tags')
+    op.drop_column('prompts', 'title')

--- a/services/api/alembic/versions/b1e8d8e2c3d0_mp_pmt_002_prompt_metadata.py
+++ b/services/api/alembic/versions/b1e8d8e2c3d0_mp_pmt_002_prompt_metadata.py
@@ -12,12 +12,16 @@ depends_on = None
 
 def upgrade() -> None:
     # prompts table
-    op.add_column('prompts', sa.Column('title', sa.String(), nullable=False))
+    op.add_column('prompts', sa.Column('title', sa.String(), nullable=True))
     op.add_column('prompts', sa.Column('tags', postgresql.ARRAY(sa.String()), nullable=True))
     op.add_column(
         'prompts',
         sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
     )
+    # Set a default value for existing rows
+    op.execute("UPDATE prompts SET title = 'Untitled' WHERE title IS NULL")
+    # Now alter the column to be NOT NULL
+    op.alter_column('prompts', 'title', nullable=False)
     op.drop_column('prompts', 'slug')
     op.drop_column('prompts', 'latest_version_id')
     op.drop_column('prompts', 'created_by')

--- a/services/api/app/api/prompts.py
+++ b/services/api/app/api/prompts.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from app.models.prompt import Prompt, PromptCreate, PromptVersion
+from app.models.prompt import Prompt, PromptCreate
 from app.db.session import get_db
 from app.services import prompt_service
 from typing import List, Optional
@@ -15,19 +15,21 @@ def create_new_prompt(prompt: PromptCreate, db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.get("/prompts", response_model=List[PromptVersion])
+@router.get("/prompts", response_model=List[Prompt])
 def get_prompts(
     model: Optional[str] = None,
-    tool: Optional[str] = None,
-    purpose: Optional[str] = None,
-    db: Session = Depends(get_db)
+    provider: Optional[str] = None,
+    use_case: Optional[str] = None,
+    db: Session = Depends(get_db),
 ):
     try:
-        return prompt_service.list_prompts(db=db, model=model, tool=tool, purpose=purpose)
+        return prompt_service.list_prompts(
+            db=db, model=model, provider=provider, use_case=use_case
+        )
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.put("/prompts/{prompt_id}", response_model=PromptVersion)
+@router.put("/prompts/{prompt_id}", response_model=Prompt)
 def update_existing_prompt(prompt_id: uuid.UUID, prompt: PromptCreate, db: Session = Depends(get_db)):
     updated_prompt = prompt_service.update_prompt(db=db, prompt_id=prompt_id, prompt_update=prompt)
     if updated_prompt is None:

--- a/services/api/app/models/prompt.py
+++ b/services/api/app/models/prompt.py
@@ -1,82 +1,116 @@
-from pydantic import BaseModel
-from uuid import UUID
-from datetime import datetime
-from typing import List, Optional
-from sqlalchemy import Column, String, TIMESTAMP, ForeignKey, ARRAY
-from sqlalchemy.dialects.postgresql import UUID as SA_UUID
-from sqlalchemy.ext.declarative import declarative_base
+"""Prompt models and ORM definitions.
+
+This module defines Pydantic models used for request/response
+validation alongside the SQLAlchemy ORM models that persist prompt
+metadata.  The schema supports a rich set of governance fields to
+facilitate discovery and reuse of prompts.
+"""
+
+from __future__ import annotations
+
 import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import ARRAY, Column, ForeignKey, String, TIMESTAMP
+from sqlalchemy.dialects.postgresql import JSONB, UUID as SA_UUID
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.sql import func
 
 Base = declarative_base()
 
+
 class PromptBase(BaseModel):
-    title: str
-    purpose: Optional[List[str]] = None
-    models: List[str]
-    tools: Optional[List[str]] = None
-    platforms: Optional[List[str]] = None
+    """Shared properties for prompt creation and updates."""
+
+    title: str = Field(..., description="Human readable name for the prompt")
+    body: str = Field(..., description="Prompt text to be sent to the model")
+    use_cases: List[str] = Field(..., description="List of applicable use cases")
+    access_control: str = Field(..., description="Access policy for the prompt")
+    target_models: Optional[List[str]] = Field(default=None, description="LLM models this prompt targets")
+    providers: Optional[List[str]] = Field(default=None, description="Model providers")
+    integrations: Optional[List[str]] = Field(default=None, description="Tooling integrations")
+    category: Optional[str] = None
+    complexity: Optional[str] = None
+    audience: Optional[str] = None
+    status: Optional[str] = None
+    input_schema: Optional[Dict[str, Any]] = None
+    output_format: Optional[str] = None
+    llm_parameters: Optional[Dict[str, Any]] = None
+    success_metrics: Optional[Dict[str, Any]] = None
+    sample_input: Optional[Dict[str, Any]] = None
+    sample_output: Optional[Dict[str, Any]] = None
+    related_prompt_ids: Optional[List[UUID]] = None
+    link: Optional[str] = None
     tags: Optional[List[str]] = None
-    body: str
-    visibility: str = 'private'
+
 
 class PromptCreate(PromptBase):
-    pass
+    """Model used when creating a new prompt version."""
+
 
 class Prompt(PromptBase):
-    id: UUID
-    version: int
-    created_at: datetime
-    prompt_id: UUID
+    """Model returned from API responses representing a prompt version."""
 
-    class Config:
-        orm_mode = True
-
-class PromptVersion(BaseModel):
     id: UUID
     prompt_id: UUID
-    version: int
-    title: str
-    purpose: Optional[List[str]] = None
-    models: List[str]
-    tools: Optional[List[str]] = None
-    platforms: Optional[List[str]] = None
-    tags: Optional[List[str]] = None
-    body: str
-    visibility: str
+    version: str
     created_at: datetime
+    updated_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = {
+        "from_attributes": True,
+    }
 
-class PromptHeader(BaseModel):
-    id: UUID
-    slug: Optional[str] = None
-    latest_version_id: Optional[UUID] = None
-    created_at: datetime
-    created_by: Optional[UUID] = None
-
-    class Config:
-        orm_mode = True
 
 class PromptHeaderORM(Base):
-    __tablename__ = 'prompts'
-    id = Column(SA_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    slug = Column(String, nullable=True)
-    latest_version_id = Column(SA_UUID(as_uuid=True), nullable=True)
-    created_at = Column(TIMESTAMP(timezone=True), nullable=False)
-    created_by = Column(SA_UUID(as_uuid=True), nullable=True)
+    """ORM model for the prompts table containing prompt level fields."""
 
-class PromptVersionORM(Base):
-    __tablename__ = 'prompt_versions'
+    __tablename__ = "prompts"
+
     id = Column(SA_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    prompt_id = Column(SA_UUID(as_uuid=True), ForeignKey('prompts.id'), nullable=False)
-    version = Column(String, nullable=False)
     title = Column(String, nullable=False)
-    purpose = Column(ARRAY(String), nullable=True)
-    models = Column(ARRAY(String), nullable=False)
-    tools = Column(ARRAY(String), nullable=True)
-    platforms = Column(ARRAY(String), nullable=True)
     tags = Column(ARRAY(String), nullable=True)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+class PromptVersionORM(Base):
+    """ORM model for individual versions of a prompt."""
+
+    __tablename__ = "prompt_versions"
+
+    id = Column(SA_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    prompt_id = Column(SA_UUID(as_uuid=True), ForeignKey("prompts.id"), nullable=False)
+    version = Column(String, nullable=False)
     body = Column(String, nullable=False)
-    visibility = Column(String, nullable=False)
-    created_at = Column(TIMESTAMP(timezone=True), nullable=False)
+    description = Column(String, nullable=True)
+    access_control = Column(String, nullable=False)
+    target_models = Column(ARRAY(String), nullable=True)
+    providers = Column(ARRAY(String), nullable=True)
+    integrations = Column(ARRAY(String), nullable=True)
+    use_cases = Column(ARRAY(String), nullable=False)
+    category = Column(String, nullable=True)
+    complexity = Column(String, nullable=True)
+    audience = Column(String, nullable=True)
+    status = Column(String, nullable=True)
+    input_schema = Column(JSONB, nullable=True)
+    output_format = Column(String, nullable=True)
+    llm_parameters = Column(JSONB, nullable=True)
+    success_metrics = Column(JSONB, nullable=True)
+    sample_input = Column(JSONB, nullable=True)
+    sample_output = Column(JSONB, nullable=True)
+    related_prompt_ids = Column(ARRAY(SA_UUID(as_uuid=True)), nullable=True)
+    link = Column(String, nullable=True)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/services/api/app/services/prompt_service.py
+++ b/services/api/app/services/prompt_service.py
@@ -1,106 +1,178 @@
-from sqlalchemy.orm import Session
-from app.models.prompt import PromptCreate, PromptHeaderORM, PromptVersion, PromptVersionORM
-import uuid
-from datetime import datetime
+"""Service layer for prompt CRUD operations."""
 
-def create_prompt(db: Session, prompt: PromptCreate):
-    # Create the prompt header
+from datetime import datetime
+import uuid
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from app.models.prompt import (
+    Prompt,
+    PromptCreate,
+    PromptHeaderORM,
+    PromptVersionORM,
+)
+
+
+def _clean_array(values: List[str] | None) -> List[str]:
+    """Remove ``None`` values from arrays returned by SQLAlchemy."""
+
+    return [v for v in values or [] if v is not None]
+
+
+def create_prompt(db: Session, prompt: PromptCreate) -> Prompt:
+    """Create a new prompt and its initial version.
+
+    Args:
+        db: Active database session.
+        prompt: Payload describing the prompt.
+
+    Returns:
+        Prompt: Serialized prompt version including header fields.
+    """
+
     prompt_header = PromptHeaderORM(
         id=uuid.uuid4(),
-        created_by=None, # TODO: Add user ID when auth is implemented
+        title=prompt.title,
+        tags=prompt.tags or None,
         created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
     )
     db.add(prompt_header)
     db.commit()
     db.refresh(prompt_header)
 
-    # Create the first prompt version
-    prompt_version_orm = PromptVersionORM(
+    version_orm = PromptVersionORM(
         id=uuid.uuid4(),
         prompt_id=prompt_header.id,
-        version=1,
-        title=prompt.title,
-        purpose=prompt.purpose if prompt.purpose else None,
-        models=prompt.models,
-        tools=prompt.tools if prompt.tools else None,
-        platforms=prompt.platforms if prompt.platforms else None,
-        tags=prompt.tags if prompt.tags else None,
+        version="1",
         body=prompt.body,
-        visibility=prompt.visibility,
+        description=None,
+        access_control=prompt.access_control,
+        target_models=prompt.target_models or None,
+        providers=prompt.providers or None,
+        integrations=prompt.integrations or None,
+        use_cases=prompt.use_cases,
+        category=prompt.category,
+        complexity=prompt.complexity,
+        audience=prompt.audience,
+        status=prompt.status,
+        input_schema=prompt.input_schema,
+        output_format=prompt.output_format,
+        llm_parameters=prompt.llm_parameters,
+        success_metrics=prompt.success_metrics,
+        sample_input=prompt.sample_input,
+        sample_output=prompt.sample_output,
+        related_prompt_ids=prompt.related_prompt_ids or None,
+        link=prompt.link,
         created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
     )
-    db.add(prompt_version_orm)
+    db.add(version_orm)
     db.commit()
-    db.refresh(prompt_version_orm)
+    db.refresh(version_orm)
 
-    # Update the prompt header with the latest version
-    prompt_header.latest_version_id = prompt_version_orm.id
-    db.commit()
-
-    # Return Pydantic model for serialization
-    def clean_array(arr):
-        return [x for x in arr if x is not None]
-    return PromptVersion(
-        id=prompt_version_orm.id,
-        prompt_id=prompt_version_orm.prompt_id,
-        version=prompt_version_orm.version,
-        title=prompt_version_orm.title,
-        purpose=clean_array(prompt_version_orm.purpose) if prompt_version_orm.purpose else [],
-        models=clean_array(prompt_version_orm.models) if prompt_version_orm.models else [],
-        tools=clean_array(prompt_version_orm.tools) if prompt_version_orm.tools else [],
-        tags=clean_array(prompt_version_orm.tags) if prompt_version_orm.tags else [],
-        body=prompt_version_orm.body,
-        visibility=prompt_version_orm.visibility,
-        created_at=prompt_version_orm.created_at,
+    return Prompt(
+        id=version_orm.id,
+        prompt_id=version_orm.prompt_id,
+        version=version_orm.version,
+        title=prompt_header.title,
+        body=version_orm.body,
+        use_cases=_clean_array(version_orm.use_cases),
+        access_control=version_orm.access_control,
+        target_models=_clean_array(version_orm.target_models),
+        providers=_clean_array(version_orm.providers),
+        integrations=_clean_array(version_orm.integrations),
+        category=version_orm.category,
+        complexity=version_orm.complexity,
+        audience=version_orm.audience,
+        status=version_orm.status,
+        input_schema=version_orm.input_schema,
+        output_format=version_orm.output_format,
+        llm_parameters=version_orm.llm_parameters,
+        success_metrics=version_orm.success_metrics,
+        sample_input=version_orm.sample_input,
+        sample_output=version_orm.sample_output,
+        related_prompt_ids=version_orm.related_prompt_ids,
+        link=version_orm.link,
+        tags=_clean_array(prompt_header.tags),
+        created_at=version_orm.created_at,
+        updated_at=version_orm.updated_at,
     )
 
-def list_prompts(db: Session, model: str = None, tool: str = None, purpose: str = None):
-    query = db.query(PromptVersionORM)
+
+def list_prompts(
+    db: Session,
+    model: str | None = None,
+    provider: str | None = None,
+    use_case: str | None = None,
+) -> List[Prompt]:
+    """List prompts applying optional filters."""
+
+    query = db.query(PromptVersionORM).join(PromptHeaderORM)
 
     if model:
-        query = query.filter(PromptVersionORM.models.any(model))
-    if tool:
-        query = query.filter(PromptVersionORM.tools.any(tool))
-    if purpose:
-        query = query.filter(PromptVersionORM.purpose.any(purpose))
+        query = query.filter(PromptVersionORM.target_models.any(model))
+    if provider:
+        query = query.filter(PromptVersionORM.providers.any(provider))
+    if use_case:
+        query = query.filter(PromptVersionORM.use_cases.any(use_case))
 
-    def clean_array(arr):
-        return [x for x in arr if x is not None]
-
-    def serialize_prompt_version(orm_obj):
-        return PromptVersion(
-            id=orm_obj.id,
-            prompt_id=orm_obj.prompt_id,
-            version=orm_obj.version,
-            title=orm_obj.title,
-            purpose=clean_array(orm_obj.purpose) if orm_obj.purpose else [],
-            models=clean_array(orm_obj.models) if orm_obj.models else [],
-            tools=clean_array(orm_obj.tools) if orm_obj.tools else [],
-            tags=clean_array(orm_obj.tags) if orm_obj.tags else [],
-            body=orm_obj.body,
-            visibility=orm_obj.visibility,
-            created_at=orm_obj.created_at,
+    results: List[Prompt] = []
+    for orm_obj in query.order_by(PromptVersionORM.created_at.desc()).all():
+        header = db.query(PromptHeaderORM).get(orm_obj.prompt_id)
+        results.append(
+            Prompt(
+                id=orm_obj.id,
+                prompt_id=orm_obj.prompt_id,
+                version=orm_obj.version,
+                title=header.title if header else "",
+                body=orm_obj.body,
+                use_cases=_clean_array(orm_obj.use_cases),
+                access_control=orm_obj.access_control,
+                target_models=_clean_array(orm_obj.target_models),
+                providers=_clean_array(orm_obj.providers),
+                integrations=_clean_array(orm_obj.integrations),
+                category=orm_obj.category,
+                complexity=orm_obj.complexity,
+                audience=orm_obj.audience,
+                status=orm_obj.status,
+                input_schema=orm_obj.input_schema,
+                output_format=orm_obj.output_format,
+                llm_parameters=orm_obj.llm_parameters,
+                success_metrics=orm_obj.success_metrics,
+                sample_input=orm_obj.sample_input,
+                sample_output=orm_obj.sample_output,
+                related_prompt_ids=orm_obj.related_prompt_ids,
+                link=orm_obj.link,
+                tags=_clean_array(header.tags) if header else [],
+                created_at=orm_obj.created_at,
+                updated_at=orm_obj.updated_at,
+            )
         )
 
-    return [serialize_prompt_version(obj) for obj in query.order_by(PromptVersionORM.created_at.desc()).all()]
+    return results
 
 
 def update_prompt(db: Session, prompt_id: uuid.UUID, prompt_update: PromptCreate):
-    # For this implementation, we'll find the latest version and update it.
-    # A more robust versioning system would create a new version.
-    latest_version = db.query(PromptVersionORM)\
-        .filter(PromptVersionORM.prompt_id == prompt_id)\
-        .order_by(PromptVersionORM.version.desc())\
+    """Update the latest version of a prompt."""
+
+    latest_version = (
+        db.query(PromptVersionORM)
+        .filter(PromptVersionORM.prompt_id == prompt_id)
+        .order_by(PromptVersionORM.version.desc())
         .first()
+    )
 
     if not latest_version:
         return None
 
-    update_data = prompt_update.dict(exclude_unset=True)
+    update_data = prompt_update.model_dump(exclude_unset=True)
     for key, value in update_data.items():
-        setattr(latest_version, key, value)
+        if hasattr(latest_version, key):
+            setattr(latest_version, key, value)
 
-    latest_version.created_at = datetime.utcnow() # To reflect the update time
+    latest_version.updated_at = datetime.utcnow()
     db.commit()
     db.refresh(latest_version)
 

--- a/services/api/app/tests/test_prompts.py
+++ b/services/api/app/tests/test_prompts.py
@@ -1,23 +1,32 @@
-from app.services.prompt_service import create_prompt
-from app.models.prompt import PromptCreate
+from app.services.prompt_service import create_prompt, list_prompts
+from app.models.prompt import PromptCreate, PromptVersionORM
 from sqlalchemy.orm import Session
 from unittest.mock import MagicMock
+import pytest
+from pydantic import ValidationError
 
 def test_create_prompt():
     mock_db = MagicMock(spec=Session)
     prompt_data = PromptCreate(
         title="Test Prompt",
         body="This is a test prompt.",
-        models=["gpt-3.5-turbo"],
+        use_cases=["testing"],
+        access_control="public",
+        target_models=["gpt-3.5-turbo"],
     )
 
     prompt = create_prompt(db=mock_db, prompt=prompt_data)
 
     assert prompt.title == "Test Prompt"
-    assert prompt.version == 1
+    assert prompt.version == "1"
     assert mock_db.add.call_count == 2
-    assert mock_db.commit.call_count == 3
+    assert mock_db.commit.call_count == 2
     assert mock_db.refresh.call_count == 2
+
+
+def test_missing_required_fields():
+    with pytest.raises(ValidationError):
+        PromptCreate(title="T", body="B", use_cases=["a"])
 
 def test_list_prompts_with_filters():
     mock_db = MagicMock(spec=Session)
@@ -25,11 +34,10 @@ def test_list_prompts_with_filters():
 
     # Simulate the chaining of filter calls
     mock_query.filter.return_value = mock_query
+    mock_query.join.return_value = mock_query
+    mock_query.order_by.return_value.all.return_value = []
 
-    from app.services.prompt_service import list_prompts
-    from app.models.prompt import PromptVersionORM
-
-    list_prompts(mock_db, model="gpt-4", tool="python", purpose="test")
+    list_prompts(mock_db, model="gpt-4", provider="openai", use_case="test")
 
     # Check that query was called on the correct table
     mock_db.query.assert_called_once_with(PromptVersionORM)


### PR DESCRIPTION
## Summary
- expand prompt model and API with rich governance metadata
- add UI scaffolding for advanced prompt details and related links
- document prompt metadata spec and update changelog

## Testing
- `PYTHONPATH=. uv run pytest -q`
- `npm test --silent` *(fails: Jest failed to parse TypeScript/JSX modules)*

------
https://chatgpt.com/codex/tasks/task_e_6893cdb7117883218135b493832d18a7