### PR TITLE
feat: add advanced and governance tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ discovery and reuse.  Each prompt captures:
 * **access_control** – one of `public`, `private`, `team-only`, or
   `role-based`.
 * Optional details such as target models, providers, integrations,
-  audience, input/output samples and related prompt links.
+  category, complexity, audience, status, input schemas, LLM parameters,
+  sample inputs/outputs, related prompt links, and reference URLs.
 
 Timestamps for creation and last modification are managed by the
 database.  See the OpenAPI docs for the full schema.

--- a/apps/web/src/components/forms/__tests__/ManualPromptForm.test.tsx
+++ b/apps/web/src/components/forms/__tests__/ManualPromptForm.test.tsx
@@ -1,0 +1,26 @@
+import { manualPromptFormSchema } from '../ManualPromptForm';
+
+describe('manualPromptFormSchema', () => {
+  const base = {
+    title: 'Test',
+    body: 'Body',
+    use_cases: ['example'],
+    target_models: ['gpt-4'],
+    access_control: 'public',
+  };
+
+  it('parses JSON fields to objects', () => {
+    const result = manualPromptFormSchema.parse({
+      ...base,
+      llm_parameters: '{"temperature":0.7}',
+    });
+    expect(result.llm_parameters).toEqual({ temperature: 0.7 });
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => manualPromptFormSchema.parse({
+      ...base,
+      input_schema: '{invalid}',
+    })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add Advanced and Governance sections to ManualPromptForm
- capture extra metadata fields and validate JSON structures
- document prompt metadata and add schema unit tests

## Testing
- `npm test` *(fails: Unknown env config "http-proxy")*
- `pnpm --filter web test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6894bb5bea8c83219dc61912da5e5972