### PR TITLE
Add metadata field help and tooltip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ discovery and reuse.  Each prompt captures:
 Timestamps for creation and last modification are managed by the
 database.  See the OpenAPI docs for the full schema.
 
+## Field Help
+
+Tooltip text for form fields such as target models, providers, and integrations is configured in `config/field_help.json` and available from the `/api/v1/metadata/fields` endpoint.
+
 ## License
 
 This template is provided under the terms of the [MIT License](LICENSE).  See the `LICENSE` file for details.

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -2,11 +2,12 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': 'babel-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   moduleNameMapper: {
     '^react$': '<rootDir>/node_modules/react',
     '^react-dom$': '<rootDir>/node_modules/react-dom',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
 };

--- a/apps/web/src/components/forms/ManualPromptForm.tsx
+++ b/apps/web/src/components/forms/ManualPromptForm.tsx
@@ -7,6 +7,7 @@ import { usePrompt } from '@/contexts/PromptContext';
 import CreatableMultiSelect from '../form/CreatableMultiSelect';
 import TagInput from '../form/TagInput';
 import { useLookups } from '@/contexts/LookupContext';
+import { useFieldHelp } from '@/contexts/FieldHelpContext';
 
 const schema = z.object({
   title: z.string().min(1, 'Title is required'),
@@ -22,6 +23,7 @@ const schema = z.object({
 const ManualPromptForm = ({ onClose }) => {
   const { createPrompt } = usePrompt();
   const { lookups, addLookup } = useLookups();
+  const { help } = useFieldHelp();
 
 
   const {
@@ -84,7 +86,7 @@ const ManualPromptForm = ({ onClose }) => {
       {/* Target Models */}
       <div>
         <label htmlFor="target_models" className="block text-sm font-medium text-gray-700">
-          Target Models
+          Target Models{help.target_models && (<span className="ml-1 text-gray-400 cursor-help" title={help.target_models}>ⓘ</span>)}
         </label>
         <Controller
           name="target_models"
@@ -114,7 +116,7 @@ const ManualPromptForm = ({ onClose }) => {
 
       {/* Providers */}
       <div>
-        <label htmlFor="providers" className="block text-sm font-medium text-gray-700">Providers</label>
+        <label htmlFor="providers" className="block text-sm font-medium text-gray-700">Providers{help.providers && (<span className="ml-1 text-gray-400 cursor-help" title={help.providers}>ⓘ</span>)}</label>
         <Controller name="providers" control={control} render={({ field }) => (
             <CreatableMultiSelect isLoading={lookups.loading} options={lookups.providers} value={lookups.providers.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('providers')} />
         )} />
@@ -123,7 +125,7 @@ const ManualPromptForm = ({ onClose }) => {
 
       {/* Integrations */}
       <div>
-        <label htmlFor="integrations" className="block text-sm font-medium text-gray-700">Integrations</label>
+        <label htmlFor="integrations" className="block text-sm font-medium text-gray-700">Integrations{help.integrations && (<span className="ml-1 text-gray-400 cursor-help" title={help.integrations}>ⓘ</span>)}</label>
         <Controller name="integrations" control={control} render={({ field }) => (
             <CreatableMultiSelect isLoading={lookups.loading} options={lookups.integrations} value={lookups.integrations.filter(o => field.value?.includes(o.value))} onChange={(options) => field.onChange(options.map(o => o.value))} onCreateOption={handleCreateOption('integrations')} />
         )} />

--- a/apps/web/src/components/forms/__tests__/ManualPromptForm.test.ts
+++ b/apps/web/src/components/forms/__tests__/ManualPromptForm.test.ts
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ManualPromptForm from '../ManualPromptForm';
+
+jest.mock('../../form/TagInput', () => {
+  const React = require('react');
+  return () => React.createElement('div');
+});
+jest.mock('../../form/CreatableMultiSelect', () => {
+  const React = require('react');
+  return () => React.createElement('div');
+});
+
+jest.mock('../../../contexts/PromptContext', () => ({
+  usePrompt: () => ({ createPrompt: jest.fn() }),
+}));
+
+jest.mock('../../../contexts/LookupContext', () => ({
+  useLookups: () => ({
+    lookups: { target_models: [], providers: [], integrations: [], use_cases: [], loading: false },
+    addLookup: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../contexts/FieldHelpContext', () => ({
+  useFieldHelp: () => ({
+    help: {
+      target_models: 'Target models help',
+      providers: 'Providers help',
+      integrations: 'Integrations help',
+    },
+    loading: false,
+  }),
+}));
+
+describe('ManualPromptForm', () => {
+  it('renders field help tooltips', () => {
+    render(React.createElement(ManualPromptForm, { onClose: () => {} }));
+    expect(screen.getByTitle('Target models help')).toBeInTheDocument();
+    expect(screen.getByTitle('Providers help')).toBeInTheDocument();
+    expect(screen.getByTitle('Integrations help')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/contexts/FieldHelpContext.tsx
+++ b/apps/web/src/contexts/FieldHelpContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { getFieldHelp, FieldHelp } from '../lib/api/metadata';
+
+interface FieldHelpContextType {
+  help: FieldHelp;
+  loading: boolean;
+}
+
+const defaultHelp: FieldHelp = {
+  target_models: '',
+  providers: '',
+  integrations: '',
+};
+
+const FieldHelpContext = createContext<FieldHelpContextType | undefined>(undefined);
+
+export const FieldHelpProvider = ({ children }: { children: ReactNode }) => {
+  const [help, setHelp] = useState<FieldHelp>(defaultHelp);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchHelp = async () => {
+      try {
+        const data = await getFieldHelp();
+        setHelp(data);
+      } catch (err) {
+        console.error('Failed to fetch field help', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchHelp();
+  }, []);
+
+  return (
+    <FieldHelpContext.Provider value={{ help, loading }}>
+      {children}
+    </FieldHelpContext.Provider>
+  );
+};
+
+export const useFieldHelp = (): FieldHelpContextType => {
+  const context = useContext(FieldHelpContext);
+  if (!context) {
+    throw new Error('useFieldHelp must be used within a FieldHelpProvider');
+  }
+  return context;
+};

--- a/apps/web/src/lib/api/metadata.ts
+++ b/apps/web/src/lib/api/metadata.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export interface FieldHelp {
+  target_models: string;
+  providers: string;
+  integrations: string;
+}
+
+export const getFieldHelp = async (): Promise<FieldHelp> => {
+  const response = await axios.get(`${API_BASE_URL}/api/v1/metadata/fields`);
+  return response.data;
+};

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -3,14 +3,17 @@ import type { AppProps } from 'next/app'
 import Layout from '@/components/Layout'
 import { PromptProvider } from '@/contexts/PromptContext'
 import { LookupProvider } from '@/contexts/LookupContext'
+import { FieldHelpProvider } from '@/contexts/FieldHelpContext'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <PromptProvider>
       <LookupProvider>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <FieldHelpProvider>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </FieldHelpProvider>
       </LookupProvider>
     </PromptProvider>
   )

--- a/config/field_help.json
+++ b/config/field_help.json
@@ -1,0 +1,5 @@
+{
+  "target_models": "List of language models the prompt targets.",
+  "providers": "Model providers associated with the prompt.",
+  "integrations": "External tools or services the prompt integrates with."
+}

--- a/services/api/app/api/endpoints/metadata.py
+++ b/services/api/app/api/endpoints/metadata.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, HTTPException
+from json import JSONDecodeError
+
+from ...services.metadata_service import get_field_help, FieldHelp
+
+router = APIRouter()
+
+
+@router.get("/fields", response_model=FieldHelp)
+async def field_help() -> FieldHelp:
+    """Return tooltip help text for known form fields."""
+    try:
+        return get_field_help()
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except JSONDecodeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -28,9 +28,10 @@ def create_app() -> FastAPI:
         return {"status": "ok"}
 
     from app.api import prompts
-    from app.api.endpoints import lookups
+    from app.api.endpoints import lookups, metadata
     app.include_router(prompts.router, prefix="/api/v1")
     app.include_router(lookups.router, prefix="/api/v1/lookups", tags=["lookups"])
+    app.include_router(metadata.router, prefix="/api/v1/metadata", tags=["metadata"])
 
     return app
 

--- a/services/api/app/services/metadata_service.py
+++ b/services/api/app/services/metadata_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Service helpers for metadata operations."""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+import json
+
+from pydantic import BaseModel
+
+
+class FieldHelp(BaseModel):
+    """Mapping of field names to help text shown as tooltips."""
+
+    target_models: str
+    providers: str
+    integrations: str
+
+
+@lru_cache
+def get_field_help() -> FieldHelp:
+    """Load tooltip help text for form fields from the configuration file.
+
+    Returns:
+        FieldHelp: An object containing help text for each supported field.
+
+    Raises:
+        FileNotFoundError: If the configuration file does not exist.
+        json.JSONDecodeError: If the configuration file contains invalid JSON.
+    """
+    base_dir = Path(__file__).resolve().parents[4]
+    config_path = base_dir / "config" / "field_help.json"
+    with config_path.open("r", encoding="utf-8") as f:
+        data: Dict[str, str] = json.load(f)
+    return FieldHelp(**data)

--- a/services/api/app/tests/test_metadata.py
+++ b/services/api/app/tests/test_metadata.py
@@ -1,0 +1,14 @@
+import pytest
+from httpx import AsyncClient
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_field_help_endpoint() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/api/v1/metadata/fields")
+    assert response.status_code == 200
+    data = response.json()
+    assert "target_models" in data
+    assert "providers" in data
+    assert "integrations" in data


### PR DESCRIPTION
## Summary
- load field help descriptions from `config/field_help.json`
- expose `/api/v1/metadata/fields` endpoint
- show field help tooltips in prompt form via new context provider

## Testing
- `pre-commit run --files config/field_help.json services/api/app/services/metadata_service.py services/api/app/api/endpoints/metadata.py services/api/app/main.py services/api/app/tests/test_metadata.py apps/web/src/lib/api/metadata.ts apps/web/src/contexts/FieldHelpContext.tsx apps/web/src/pages/_app.tsx apps/web/src/components/forms/ManualPromptForm.tsx apps/web/src/components/forms/__tests__/ManualPromptForm.test.ts README.md`
- `PYTHONPATH=. uv run pytest app/tests/test_metadata.py`
- `pnpm --filter ./apps/web test src/components/forms/__tests__/ManualPromptForm.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6894bb6162148321a16607bfaa82e38e