### PR TITLE
MP-P1-UI-004: Vault list/grid + prompt cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 - Initial skeleton structure for React Native + FastAPI monorepo template.
 - MP-PMT-002: expanded prompt metadata model, CRUD APIs and UI scaffolding.
+- MP-P1-UI-004: vault list grid with prompt cards, filters, and detail modal.

--- a/apps/web/public/locales/en/translation.json
+++ b/apps/web/public/locales/en/translation.json
@@ -3,8 +3,9 @@
     "newPrompt": "New Prompt"
   },
   "copy": {
-    "buttonLabel": "Text copied to clipboard",
-    "error": "Failed to copy text to clipboard"
+    "buttonLabel": "Copy to clipboard",
+    "error": "Failed to copy text to clipboard",
+    "success": "Copied to clipboard"
   },
   "form": {
     "title": "Title",

--- a/apps/web/src/components/PromptCard.tsx
+++ b/apps/web/src/components/PromptCard.tsx
@@ -22,6 +22,7 @@ const Tag: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 const PromptCard: React.FC<PromptCardProps> = ({ prompt, onClick }) => {
   const allTags = prompt.tags || [];
+  const firstLine = prompt.body.split('\n')[0];
 
   return (
     <div
@@ -31,9 +32,7 @@ const PromptCard: React.FC<PromptCardProps> = ({ prompt, onClick }) => {
       <div>
         <h3 className="text-lg font-bold text-white truncate">{prompt.title}</h3>
         <div className="flex items-start mt-1">
-          <p className="text-sm text-gray-400 h-10 overflow-hidden text-ellipsis flex-1">
-            {prompt.body}
-          </p>
+          <p className="text-sm text-gray-400 truncate flex-1">{firstLine}</p>
           <CopyIconButton text={prompt.body} />
         </div>
         <div className="mt-4 flex flex-wrap gap-2">

--- a/apps/web/src/components/PromptCard.tsx
+++ b/apps/web/src/components/PromptCard.tsx
@@ -22,7 +22,7 @@ const Tag: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 const PromptCard: React.FC<PromptCardProps> = ({ prompt, onClick }) => {
   const allTags = prompt.tags || [];
-  const firstLine = prompt.body.split('\n')[0];
+  const firstLine = (prompt.body ?? '').split('\n')[0];
 
   return (
     <div

--- a/apps/web/src/components/__tests__/PromptCard.test.tsx
+++ b/apps/web/src/components/__tests__/PromptCard.test.tsx
@@ -7,7 +7,7 @@ describe('PromptCard', () => {
     id: '1',
     title: 'Test Prompt',
     body: 'This is the body of the prompt.',
-    version: 1,
+    version: '1',
     purpose: ['testing'],
     models: ['gpt-4'],
     tags: ['tag1', 'tag2'],
@@ -37,5 +37,6 @@ describe('PromptCard', () => {
     const button = screen.getByLabelText('Copy to clipboard');
     fireEvent.click(button);
     expect(writeText).toHaveBeenCalledWith('This is the body of the prompt.');
+    expect(screen.getByText('Copied to clipboard')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/common/CopyIconButton.tsx
+++ b/apps/web/src/components/common/CopyIconButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Copy } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import Toast from './Toast';
 
 interface CopyIconButtonProps {
   text: string;
@@ -22,16 +23,19 @@ const CopyIconButton: React.FC<CopyIconButtonProps> = ({ text }) => {
   };
 
   return (
-    <button aria-label={t('copy.buttonLabel')} onClick={handleCopy} className="ml-2 text-gray-400 hover:text-gray-200">
-      <Copy className="w-4 h-4" />
-      <span
-        className="sr-only"
-        aria-live="polite"
-        aria-atomic="true"
+    <>
+      <button
+        aria-label={t('copy.buttonLabel')}
+        onClick={handleCopy}
+        className="ml-2 text-gray-400 hover:text-gray-200"
       >
-        {copied ? t('copy.success') : ''}
-      </span>
-    </button>
+        <Copy className="w-4 h-4" />
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          {copied ? t('copy.success') : ''}
+        </span>
+      </button>
+      {copied && <Toast message={t('copy.success')} />}
+    </>
   );
 };
 

--- a/apps/web/src/components/common/Toast.tsx
+++ b/apps/web/src/components/common/Toast.tsx
@@ -5,12 +5,27 @@ interface ToastProps {
 }
 
 const Toast: React.FC<ToastProps> = ({ message }) => (
-  <div
-    role="status"
-    className="fixed bottom-4 right-4 bg-gray-900 text-white px-4 py-2 rounded shadow"
-  >
-    {message}
-  </div>
+  <>
+    <div
+      role="status"
+      className="toast"
+    >
+      {message}
+    </div>
+    <style jsx>{`
+      .toast {
+        position: fixed;
+        bottom: var(--toast-spacing-bottom, 1rem);
+        right: var(--toast-spacing-right, 1rem);
+        background: var(--toast-bg, #1a202c);
+        color: var(--toast-color, #fff);
+        padding: var(--toast-padding, 1rem 1.5rem);
+        border-radius: var(--toast-radius, 0.5rem);
+        box-shadow: var(--toast-shadow, 0 2px 8px rgba(0,0,0,0.15));
+        z-index: var(--toast-z-index, 1000);
+      }
+    `}</style>
+  </>
 );
 
 export default Toast;

--- a/apps/web/src/components/common/Toast.tsx
+++ b/apps/web/src/components/common/Toast.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface ToastProps {
+  message: string;
+}
+
+const Toast: React.FC<ToastProps> = ({ message }) => (
+  <div
+    role="status"
+    className="fixed bottom-4 right-4 bg-gray-900 text-white px-4 py-2 rounded shadow"
+  >
+    {message}
+  </div>
+);
+
+export default Toast;

--- a/apps/web/src/components/common/__tests__/CopyIconButton.test.tsx
+++ b/apps/web/src/components/common/__tests__/CopyIconButton.test.tsx
@@ -14,5 +14,6 @@ describe('CopyIconButton', () => {
     render(<CopyIconButton text="copy me" />);
     fireEvent.click(screen.getByRole('button'));
     expect(writeText).toHaveBeenCalledWith('copy me');
+    expect(screen.getByText('Copied to clipboard')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/filters/PromptListFilters.tsx
+++ b/apps/web/src/components/filters/PromptListFilters.tsx
@@ -18,7 +18,7 @@ interface Option {
 
 const PromptListFilters: React.FC = () => {
   const { lookups } = useLookups();
-  const { filterPrompts } = usePrompt(); // Assuming usePrompt returns a filter function
+  const { filterPrompts } = usePrompt();
 
   const [modelFilter, setModelFilter] = useState<readonly Option[]>([]);
   const [toolFilter, setToolFilter] = useState<readonly Option[]>([]);
@@ -30,8 +30,14 @@ const PromptListFilters: React.FC = () => {
       tool: toolFilter.length > 0 ? toolFilter[0].value : undefined,
       purpose: purposeFilter.length > 0 ? purposeFilter[0].value : undefined,
     };
-    // filterPrompts(filters);
-    console.log("Applying filters:", filters);
+    filterPrompts(filters);
+  };
+
+  const handleClear = () => {
+    setModelFilter([]);
+    setToolFilter([]);
+    setPurposeFilter([]);
+    filterPrompts({});
   };
 
   return (
@@ -78,7 +84,10 @@ const PromptListFilters: React.FC = () => {
             />
           </div>
         </div>
-        <Button onClick={handleApplyFilters} className="w-full">Apply Filters</Button>
+        <div className="flex gap-2">
+          <Button onClick={handleApplyFilters} className="flex-1">Apply</Button>
+          <Button variant="outline" onClick={handleClear} className="flex-1">Clear</Button>
+        </div>
       </SheetContent>
     </Sheet>
   );

--- a/apps/web/src/contexts/PromptContext.tsx
+++ b/apps/web/src/contexts/PromptContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useReducer, useEffect, FC, ReactNode, useContext } from 'react';
-import { fetchPrompts } from '@/lib/api/fetchPrompts';
+import { fetchPrompts, PromptFilters } from '@/lib/api/fetchPrompts';
 import { createPrompt as createPromptApi } from '@/lib/api/createPrompt';
 import { Prompt, ManualPromptInput } from '@/types/Prompt';
 
@@ -15,6 +15,7 @@ interface PromptContextType {
   state: PromptState;
   dispatch: React.Dispatch<PromptAction>;
   createPrompt: (prompt: ManualPromptInput) => Promise<void>;
+  filterPrompts: (filters: PromptFilters) => Promise<void>;
 }
 
 interface PromptProviderProps {
@@ -46,8 +47,13 @@ export const PromptProvider: FC<PromptProviderProps> = ({ children }) => {
     dispatch({ type: 'CREATE', payload: newPrompt });
   };
 
+  const filterPrompts = async (filters: PromptFilters) => {
+    const data = await fetchPrompts(filters);
+    dispatch({ type: 'LOAD', payload: data });
+  };
+
   return (
-    <PromptContext.Provider value={{ state, dispatch, createPrompt }}>
+    <PromptContext.Provider value={{ state, dispatch, createPrompt, filterPrompts }}>
       {children}
     </PromptContext.Provider>
   );

--- a/apps/web/src/lib/api/__tests__/fetchPrompts.test.ts
+++ b/apps/web/src/lib/api/__tests__/fetchPrompts.test.ts
@@ -1,0 +1,15 @@
+import { fetchPrompts } from '../fetchPrompts';
+import { apiRequest } from '../api_client';
+
+jest.mock('../api_client');
+
+describe('fetchPrompts', () => {
+  it('builds query string from filters', async () => {
+    (apiRequest as jest.Mock).mockResolvedValue([]);
+    await fetchPrompts({ model: 'gpt-4', tool: 'toolA', purpose: 'demo' });
+    expect(apiRequest).toHaveBeenCalledWith({
+      endpoint: '/api/v1/prompts?model=gpt-4&tool=toolA&purpose=demo',
+      method: 'GET',
+    });
+  });
+});

--- a/apps/web/src/lib/api/fetchPrompts.ts
+++ b/apps/web/src/lib/api/fetchPrompts.ts
@@ -1,9 +1,22 @@
 import { Prompt } from '@/types/Prompt';
 import { apiRequest } from './api_client';
 
-export const fetchPrompts = async (): Promise<Prompt[]> => {
+export interface PromptFilters {
+  model?: string;
+  tool?: string;
+  purpose?: string;
+}
+
+export const fetchPrompts = async (
+  filters: PromptFilters = {}
+): Promise<Prompt[]> => {
+  const params = new URLSearchParams();
+  if (filters.model) params.set('model', filters.model);
+  if (filters.tool) params.set('tool', filters.tool);
+  if (filters.purpose) params.set('purpose', filters.purpose);
+  const query = params.toString();
   return apiRequest<Prompt[]>({
-    endpoint: '/api/v1/prompts',
+    endpoint: `/api/v1/prompts${query ? `?${query}` : ''}`,
     method: 'GET',
   });
 };

--- a/apps/web/src/pages/prompts/index.tsx
+++ b/apps/web/src/pages/prompts/index.tsx
@@ -3,6 +3,8 @@ import { PromptContext } from '@/contexts/PromptContext';
 import PromptCard from '@/components/PromptCard';
 import PromptListFilters from '@/components/filters/PromptListFilters';
 import PromptDetailModal from '@/components/PromptDetailModal';
+import NewPromptModal from '@/components/modals/NewPromptModal';
+import { Button } from '@/components/ui/button';
 
 // Placeholder for the actual Prompt data type
 interface Prompt {
@@ -19,9 +21,10 @@ interface Prompt {
 
 
 const PromptsPage = () => {
-  const { state, updatePrompt } = useContext(PromptContext);
+  const { state } = useContext(PromptContext);
   const [selectedPrompt, setSelectedPrompt] = useState<Prompt | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isNewPromptOpen, setIsNewPromptOpen] = useState(false);
 
   const handleCardClick = (prompt: Prompt) => {
     setSelectedPrompt(prompt);
@@ -34,10 +37,7 @@ const PromptsPage = () => {
   };
 
   const handleSavePrompt = (updatedPrompt: Prompt) => {
-    // In a real app, you would call an API to save the prompt
-    // For now, we'll just update the context state
-    console.log("Saving prompt:", updatedPrompt);
-    // updatePrompt(updatedPrompt); // Assuming context has an update function
+    console.log('Saving prompt:', updatedPrompt);
     handleCloseModal();
   };
 
@@ -58,7 +58,10 @@ const PromptsPage = () => {
             />
           ))
         ) : (
-          <p>No prompts found.</p>
+          <div className="col-span-full text-center py-10">
+            <p className="mb-4">No prompts found.</p>
+            <Button onClick={() => setIsNewPromptOpen(true)}>New Prompt</Button>
+          </div>
         )}
       </div>
 
@@ -69,6 +72,9 @@ const PromptsPage = () => {
           onClose={handleCloseModal}
           onSave={handleSavePrompt}
         />
+      )}
+      {isNewPromptOpen && (
+        <NewPromptModal onClose={() => setIsNewPromptOpen(false)} />
       )}
     </div>
   );

--- a/docs/ui/vault.md
+++ b/docs/ui/vault.md
@@ -1,0 +1,7 @@
+# Vault View
+
+The Prompts page renders a responsive grid of prompt cards. Cards display the prompt title, the first line of the body, up to four tags, and a version badge. Each card includes a copy button that copies the full prompt body and displays a confirmation toast.
+
+Filters for model, tool, and purpose are available via the Filters drawer. Applying filters reloads the prompt list, while the Clear button resets them.
+
+When no prompts match the current filters an empty state is shown with a call-to-action button to create a new prompt.


### PR DESCRIPTION
## Summary
- add responsive prompt card body truncation and copy toast
- support prompt filtering and empty state with new prompt CTA
- document vault view and update copy translations

## Testing
- `pnpm test` *(fails: ReferenceError: cy is not defined; Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6896c062b92483218e48af4648ad23ee