### PR TITLE
Document prompts pagination parameters

### DIFF
--- a/services/api/app/models/prompt.py
+++ b/services/api/app/models/prompt.py
@@ -98,10 +98,21 @@ class Prompt(PromptBase):
 class PromptListResponse(BaseModel):
     """Paginated response model for ``GET /prompts``."""
 
-    items: List[Prompt]
-    next_cursor: Optional[str] = None
-    count: int
-    total_estimate: Optional[int] = None
+    items: List[Prompt] = Field(
+        ..., description="Prompts returned in the current page"
+    )
+    next_cursor: Optional[str] = Field(
+        default=None,
+        description=(
+            "Cursor for fetching the next page. Pass this value to the "
+            "`after` query parameter on subsequent requests."
+        ),
+    )
+    count: int = Field(..., description="Number of prompts in this response")
+    total_estimate: Optional[int] = Field(
+        default=None,
+        description="Approximate total number of prompts matching the query",
+    )
 
 
 class PromptHeaderORM(Base):

--- a/services/api/app/tests/test_prompts_openapi.py
+++ b/services/api/app/tests/test_prompts_openapi.py
@@ -1,0 +1,24 @@
+"""Tests for OpenAPI documentation of the prompts endpoint."""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("AUTH_SIGNING_SECRET", "secret")
+os.environ.setdefault("GITHUB_CLIENT_ID", "dummy")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "dummy")
+
+from app.main import app
+
+
+def test_prompts_pagination_documented() -> None:
+    """The OpenAPI schema documents cursor based pagination."""
+    schema = app.openapi()
+    params = {
+        p["name"]: p for p in schema["paths"]["/api/v1/prompts"]["get"]["parameters"]
+    }
+    after_param = params["after"]
+    assert "cursor" in after_param["description"].lower()
+
+    properties = schema["components"]["schemas"]["PromptListResponse"]["properties"]
+    next_cursor = properties["next_cursor"]
+    assert "cursor" in next_cursor["description"].lower()


### PR DESCRIPTION
## Summary
- add detailed parameter docs to prompts listing endpoint
- describe cursor-based pagination in response model
- test OpenAPI schema for cursor pagination details

## Testing
- `pre-commit run --files services/api/app/tests/test_prompts_openapi.py services/api/app/api/prompts.py services/api/app/models/prompt.py`
- `PYENV_VERSION=3.11.12 PYTHONPATH=services/api pytest services/api/app/tests/test_prompts_openapi.py -q`
- `PYENV_VERSION=3.11.12 PYTHONPATH=services/api pytest services/api/app/tests -q` *(fails: pydantic_core._pydantic_core.ValidationError: 4 validation errors for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68976805de688321b88f745887a3540c